### PR TITLE
Container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+### 1.8.14
+**sass changes**
+
+Container
+- New container modifier `a-container--fluidOnBp[breakpoint]` that makes container fluid on specific breakpoint
+- Removed `a-container--xsmall` and `a-container--small` modifiers (duplicated logic)
+
+Accordion
+- Add default flex direction column on `a-accordion__content`
+
 ### 1.8.13
 **sass changes**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prima-assicurazioni/pyxis-npm",
-  "version": "1.8.13",
+  "version": "1.8.14",
   "description": "Pyxis SASS provided by a simple NPM package",
   "main": "src/scss/pyxis.scss",
   "scripts": {

--- a/src/scss/01_base/_breakpoints.scss
+++ b/src/scss/01_base/_breakpoints.scss
@@ -8,8 +8,10 @@ $breakpoints: (
   large:   1200px,
   xlarge:  1920px,
 
-  boundDiff: 0.2px,
 ) !default;
+
+$breakpointBoundDiff: 0.2px !default;
+
 
 @mixin mq($breakpoint) {
   @if map-has-key($breakpoints, $breakpoint) {
@@ -41,7 +43,7 @@ $breakpoints: (
     @warn "Cannot find the key #{$upperBound} in the $breakpoints object (/atom/01_base/_breakpoints.scss)";
   }
   @else {
-    @media screen and (min-width: map-get($breakpoints, $lowerBound)) and (max-width: map-get($breakpoints, $upperBound) - map-get($breakpoints, boundDiff)) {
+    @media screen and (min-width: map-get($breakpoints, $lowerBound)) and (max-width: map-get($breakpoints, $upperBound) - $breakpointBoundDiff) {
       @content;
     }
   }
@@ -49,7 +51,7 @@ $breakpoints: (
 
 @mixin mqDown($breakpoint) {
   @if map-has-key($breakpoints, $breakpoint) {
-    @media screen and (max-width: map-get($breakpoints, $breakpoint) - map-get($breakpoints, boundDiff)) {
+    @media screen and (max-width: map-get($breakpoints, $breakpoint) - $breakpointBoundDiff) {
       @content;
     }
   }

--- a/src/scss/01_base/_utils.scss
+++ b/src/scss/01_base/_utils.scss
@@ -90,7 +90,7 @@
 
 }
 
-@include fontSizesByBreakpoint(map-remove($fontSizes, "root"), map-remove($breakpoints, "boundDiff"));
+@include fontSizesByBreakpoint(map-remove($fontSizes, "root"), $breakpoints );
 
 
 @mixin withNElements($selector, $n) {

--- a/src/scss/02_atoms/_accordion.scss
+++ b/src/scss/02_atoms/_accordion.scss
@@ -91,6 +91,7 @@
 
 .a-accordion__content {
   flex: 0 0 0;
+  flex-flow: column;
   padding: 0;
   opacity: 0;
   overflow: hidden;

--- a/src/scss/02_atoms/_containers.scss
+++ b/src/scss/02_atoms/_containers.scss
@@ -4,8 +4,8 @@
   width: 90%;
 
   @include mq(xsmall) {
-   max-width: map-get($containerConfig, xsmall);
-   width: 100%;
+    max-width: map-get($containerConfig, xsmall);
+    width: 100%;
   }
 
   @include mq(small) {
@@ -28,19 +28,32 @@
     width: 100%;
   }
 
-  &.a-container--xsmall {
 
-    @include mq(xsmall) {
-      max-width: map-get($containerConfig, xsmall);
-      width: 100%;
-    }
-  }
+  @each $containerKey, $size in $containerConfig {
+    $bpIndex: 1;
+    $bpLength: length($breakpoints);
 
-  &.a-container--small {
-
-    @include mq(small) {
-      max-width: map-get($containerConfig, small);
-      width: 100%;
+    @each $bpKey, $bpSize in $breakpoints {
+      @if $bpIndex == 1 {
+        &.a-container--fluidOnBpDefault {
+          @include mqDown($bpKey) {
+            width: 100%;
+          }
+        }
+      }
+      &.a-container--fluidOnBp#{capitalize($bpKey)} {
+        @if ($bpIndex + 1) <= $bpLength {
+          $nextBpKey: nth(nth($breakpoints, ($bpIndex + 1)), 1);
+          @include mqBetween($bpKey, $nextBpKey) {
+            width: 100%;
+          }
+        } @else {
+          @include mqUp($bpKey) {
+            width: 100%;
+          }
+        }
+      }
+      $bpIndex: $bpIndex + 1;
     }
   }
 }


### PR DESCRIPTION
## Changelog

### 1.8.14
**sass changes**

Container
- New container modifier `a-container--fluidOnBp[breakpoint]` that makes container fluid on specific breakpoint
- Removed `a-container--xsmall` and `a-container--small` modifiers (duplicated logic)

Accordion
- Add default flex direction column on `a-accordion__content`
