### PR TITLE
1.8.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Accordion
 - Accordion now have double border on top and bottom (accordion group modified to support this)
 
 Utils
-- New `asRem` mixin that given a css property and a pixel value generates that property in rem and pixel value (as fallback)
+- Add `rem` function to get `rem` value by passing a `px` value. At the moment this function will always return the `px` result. We planned a full switch to `rem` units in later release
 
 
 **sass fix** 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,14 @@ Container
 - **BREAKING-CHANGE**: `a-container--fluid` removed in favour of `a-containerFluid` 
 - Now you can have containers of certain type that changes behaviour on certain breakpoints combining `a-container` and `a-containerFluid` with `a-containerOn[breakpoint]` and `a-containerFluidOn[breakpoint]` 
 
-**sass fix**
+Accordion
+- Accordion now have double border on top and bottom (accordion group modified to support this)
+
+Utils
+- New `asRem` mixin that given a css property and a pixel value generates that property in rem and pixel value (as fallback)
+
+
+**sass fix** 
 
 Container
 - Now containers breakpoint are generated automatically with mixin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Utils
 Container
 - Now containers breakpoint are generated automatically with mixin
 
+Accordion
+- Accordion now apply transition on body content too
+
 **project specific**
 - Added specific test page for containers and button, please add a specific page for atoms/molecule testing in the future able to cover the majority of cases 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 ### 1.8.15
 **sass changes**
 
+Login
+- added max width equal to `a-container` xsmall
+
 Container
-- **BREAKING-CANGE**: Removed previously introduced `a-container--fluidOnBp
-- **BREAKING-CANGE**: `a-container--fluid` removed in favour of `a-containerFluid` 
+- **BREAKING-CHANGE**: Removed previously introduced `a-container--fluidOnBp
+- **BREAKING-CHANGE**: `a-container--fluid` removed in favour of `a-containerFluid` 
 - Now you can have containers of certain type that changes behaviour on certain breakpoints combining `a-container` and `a-containerFluid` with `a-containerOn[breakpoint]` and `a-containerFluidOn[breakpoint]` 
 
 **sass fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,27 @@
 ## Changelog
 
+### 1.8.15
+**sass changes**
+
+Container
+- **BREAKING-CANGE**: Removed previously introduced `a-container--fluidOnBp
+- **BREAKING-CANGE**: `a-container--fluid` removed in favour of `a-containerFluid` 
+- Now you can have containers of certain type that changes behaviour on certain breakpoints combining `a-container` and `a-containerFluid` with `a-containerOn[breakpoint]` and `a-containerFluidOn[breakpoint]` 
+
+**sass fix**
+
+Container
+- Now containers breakpoint are generated automatically with mixin
+
+**project specific**
+- Added specific test page for containers and button, please add a specific page for atoms/molecule testing in the future able to cover the majority of cases 
+
 ### 1.8.14
 **sass changes**
 
 Container
-- New container modifier `a-container--fluidOnBp[breakpoint]` that makes container fluid on specific breakpoint
+- ~~New container modifier `a-container--fluidOnBp[breakpoint]` that makes container fluid on specific breakpoint~~ **[removed in 1.8.15]**
+
 - Removed `a-container--xsmall` and `a-container--small` modifiers (duplicated logic)
 
 Accordion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prima-assicurazioni/pyxis-npm",
-  "version": "1.8.14",
+  "version": "1.8.15",
   "description": "Pyxis SASS provided by a simple NPM package",
   "main": "src/scss/pyxis.scss",
   "scripts": {

--- a/src/scss/01_base/_base.scss
+++ b/src/scss/01_base/_base.scss
@@ -24,6 +24,7 @@ body {
  height: 100%;
  width: 100%;
  -webkit-font-smoothing: antialiased;
+  margin:0;
 }
 
 input,

--- a/src/scss/01_base/_utils.scss
+++ b/src/scss/01_base/_utils.scss
@@ -1,3 +1,14 @@
+/// Remove the unit of a length
+/// @param {Number} $number - Number to remove unit from
+/// @return {Number} - Unitless number
+@function strip-unit($number) {
+  @if type-of($number) == 'number' and not unitless($number) {
+    @return $number / ($number * 0 + 1);
+  }
+
+  @return $number;
+}
+
 @each $color, $tones in $colors {
   @each $colorTone, $colorHex in $tones {
     .bg-#{$color}-#{$colorTone},
@@ -91,10 +102,19 @@
 
 @include fontSizesByBreakpoint(map-remove($fontSizes, "root"), $breakpoints );
 
-
 @mixin withNElements($selector, $n) {
   #{$selector}:first-child:nth-last-child(#{$n}),
   #{$selector}:nth-last-child(#{$n}) ~ #{$selector} {
     @content;
   }
+}
+
+/**
+  * Add rem AND pixels rule from a rule in pixels
+ */
+@mixin asRem($rule, $pixelValue) {
+  $pixelValue: strip-unit($pixelValue) + px;
+
+  #{$rule}: #{strip-unit( $pixelValue / map-get($fontSizes, root)) + rem};
+  #{$rule}: #{$pixelValue};
 }

--- a/src/scss/01_base/_utils.scss
+++ b/src/scss/01_base/_utils.scss
@@ -66,7 +66,6 @@
     $bpLength: length($breakpoints);
 
     @each $bpKey, $bpSize in $breakpoints {
-
       .fs-#{$fontKey}-on-bp-#{$bpKey},
       .fs#{capitalize($fontKey)}OnBp#{capitalize($bpKey)} {
 

--- a/src/scss/01_base/_utils.scss
+++ b/src/scss/01_base/_utils.scss
@@ -108,13 +108,8 @@
     @content;
   }
 }
-
-/**
-  * Add rem AND pixels rule from a rule in pixels
- */
-@mixin asRem($rule, $pixelValue) {
-  $pixelValue: strip-unit($pixelValue) + px;
-
-  #{$rule}: #{strip-unit( $pixelValue / map-get($fontSizes, root)) + rem};
-  #{$rule}: #{$pixelValue};
+// We will switch to rem in later release
+@function rem($amount) {
+  // @return #{strip-unit( strip-unit($amount) / map-get($fontSizes, root)) + rem};
+  @return $amount;
 }

--- a/src/scss/02_atoms/_accordion.scss
+++ b/src/scss/02_atoms/_accordion.scss
@@ -94,9 +94,15 @@
   padding: 0 map-get($accordionConfig, accordionPadding);
   opacity: 0;
   overflow: hidden;
-  transition: all 0.3s;
+  transition: opacity 0.3s, padding 0.3s, flex 0.3s, visibility 0.3s;
   visibility: hidden;
 
+  & * {
+    flex: 0 0 0;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s, padding 0.3s, flex 0.3s, visibility 0.3s;
+  }
 }
 
 .a-accordion.is-open .a-accordion__content {
@@ -106,7 +112,14 @@
   opacity: 1;
   @include asRem('padding', map-get($accordionConfig, accordionPadding));
   visibility: visible;
+
+  & * {
+    flex: 1 0 auto;
+    opacity: 1;
+    visibility: visible;
+  }
 }
+
 .a-accordion.is-open.a-accordion--dark .a-accordion__content {
   border-bottom: 1px solid color(shape, dark);
 }

--- a/src/scss/02_atoms/_accordion.scss
+++ b/src/scss/02_atoms/_accordion.scss
@@ -4,8 +4,8 @@
   display: flex;
   flex: 1 0 auto;
   flex-direction: column;
-  padding: (map-get($accordionConfig, accordionPadding) / 2) map-get($accordionConfig, accordionPadding) 0  map-get($accordionConfig, accordionPadding);
   position: relative;
+  transition: background-color 0.3s;
 
   &--light {
     background: color(background, light);
@@ -24,7 +24,6 @@
 
   &.is-open {
     background: color(background, dark);
-    padding-top: ((map-get($accordionConfig, accordionPadding) / 2));
 
     &.a-accordion--light {
       background: color(background, dark);
@@ -46,21 +45,21 @@
 
 .a-accordion__toggle {
   align-items: center;
+  border-bottom: 1px solid color(shape);
+  border-top: 1px solid color(shape);
   color: inherit;
   cursor: pointer;
   display: flex;
   flex: 1 0 auto;
   flex-direction: row;
   justify-content: space-between;
-  padding: map-get($accordionConfig, accordionPadding) 0;
+  @include asRem('padding', map-get($accordionConfig, accordionPadding));
+
   text-decoration: none;
   width: 100%;
 
-  .a-accordion.is-open & {
-    border-bottom: 1px solid color(shape);
-  }
-
-  .a-accordion.a-accordion--dark.is-open {
+  .a-accordion--dark & {
+    border-top: 1px solid color(shape, dark);
     border-bottom: 1px solid color(shape, dark);
   }
 }
@@ -92,17 +91,22 @@
 .a-accordion__content {
   flex: 0 0 0;
   flex-flow: column;
-  padding: 0;
+  padding: 0 map-get($accordionConfig, accordionPadding);
   opacity: 0;
   overflow: hidden;
   transition: all 0.3s;
   visibility: hidden;
+
 }
 
 .a-accordion.is-open .a-accordion__content {
+  border-bottom: 1px solid color(shape);
   display: flex;
   flex: 1 0 auto;
   opacity: 1;
-  padding: map-get($accordionConfig, accordionPadding) 0;
+  @include asRem('padding', map-get($accordionConfig, accordionPadding));
   visibility: visible;
+}
+.a-accordion.is-open.a-accordion--dark .a-accordion__content {
+  border-bottom: 1px solid color(shape, dark);
 }

--- a/src/scss/02_atoms/_accordion.scss
+++ b/src/scss/02_atoms/_accordion.scss
@@ -7,41 +7,38 @@
   position: relative;
   transition: background-color 0.3s;
 
-  &--light {
-    background: color(background, light);
-    color: color(text, dark);
+  &.is-open .a-icon {
+    transform: rotate(45deg);
   }
+}
 
-  &--dark {
-    background: color(backgroundAlt, dark);
-    color: color(text, light);
-  }
+.a-accordion.a-accordion--base {
+  background: color(background, dark);
+  color: color(text, dark);
 
-  &--base {
-    background: color(background, dark);
-    color: color(text, dark);
+  &.is-open {
+    background: color(background, base);
   }
+}
+
+.a-accordion.a-accordion--light {
+  background: color(background, light);
+  color: color(text, dark);
 
   &.is-open {
     background: color(background, dark);
-
-    &.a-accordion--light {
-      background: color(background, dark);
-    }
-
-    &.a-accordion--dark {
-      background: color(backgroundAlt, light);
-    }
-
-    &.a-accordion--base {
-      background: color(background, base);
-    }
-
-    .a-icon {
-      transform: rotate(45deg);
-    }
   }
 }
+
+.a-accordion.a-accordion--dark {
+  background: color(backgroundAlt, dark);
+  color: color(text, light);
+
+  &.is-open {
+    background: color(backgroundAlt, light);
+  }
+}
+
 
 .a-accordion__toggle {
   align-items: center;
@@ -53,8 +50,7 @@
   flex: 1 0 auto;
   flex-direction: row;
   justify-content: space-between;
-  @include asRem('padding', map-get($accordionConfig, accordionPadding));
-
+  padding: rem(map-get($accordionConfig, accordionPadding));
   text-decoration: none;
   width: 100%;
 
@@ -71,7 +67,8 @@
   padding: 0 (map-get($accordionConfig, accordionPadding) / 2);
   transition: all 0.3s;
 
-  &:before, &:after {
+  &:before, 
+  &:after {
     background: color(brandAlt);
     content: ' ';
     position: absolute;
@@ -81,10 +78,6 @@
 
   &:before {
     transform: rotate(90deg);
-  }
-
-  &--arrow:after {
-    content: '\E902';
   }
 }
 
@@ -97,29 +90,16 @@
   transition: opacity 0.3s, padding 0.3s, flex 0.3s, visibility 0.3s;
   visibility: hidden;
 
-  & * {
-    flex: 0 0 0;
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.3s, padding 0.3s, flex 0.3s, visibility 0.3s;
-  }
-}
-
-.a-accordion.is-open .a-accordion__content {
-  border-bottom: 1px solid color(shape);
-  display: flex;
-  flex: 1 0 auto;
-  opacity: 1;
-  @include asRem('padding', map-get($accordionConfig, accordionPadding));
-  visibility: visible;
-
-  & * {
+  .a-accordion.is-open & {
+    border-bottom: 1px solid color(shape);
+    display: flex;
     flex: 1 0 auto;
     opacity: 1;
+    padding: rem(map-get($accordionConfig, accordionPadding));
     visibility: visible;
   }
-}
 
-.a-accordion.is-open.a-accordion--dark .a-accordion__content {
-  border-bottom: 1px solid color(shape, dark);
+  .a-accordion.is-open.a-accordion--dark & {
+    border-bottom: 1px solid color(shape, dark);
+  }
 }

--- a/src/scss/02_atoms/_containers.scss
+++ b/src/scss/02_atoms/_containers.scss
@@ -3,57 +3,81 @@
   margin: 0 auto;
   width: 90%;
 
-  @include mq(xsmall) {
-    max-width: map-get($containerConfig, xsmall);
-    width: 100%;
-  }
-
-  @include mq(small) {
-    max-width: map-get($containerConfig, small);
-  }
-
-  @include mq(medium) {
-    max-width: map-get($containerConfig, medium);
-  }
-
-  @include mq(large) {
-    max-width: map-get($containerConfig, large);
-  }
-
-  @include mq(xlarge) {
-    max-width: map-get($containerConfig, xlarge);
-  }
-
-  &.a-container--fluid {
-    width: 100%;
-  }
-
-
   @each $containerKey, $size in $containerConfig {
     $bpIndex: 1;
     $bpLength: length($breakpoints);
 
     @each $bpKey, $bpSize in $breakpoints {
-      @if $bpIndex == 1 {
-        &.a-container--fluidOnBpDefault {
-          @include mqDown($bpKey) {
-            width: 100%;
-          }
-        }
+      @include mq($bpKey) {
+        max-width: map-get($containerConfig, $bpKey);
+        width: 100%;
       }
-      &.a-container--fluidOnBp#{capitalize($bpKey)} {
-        @if ($bpIndex + 1) <= $bpLength {
-          $nextBpKey: nth(nth($breakpoints, ($bpIndex + 1)), 1);
-          @include mqBetween($bpKey, $nextBpKey) {
-            width: 100%;
-          }
-        } @else {
-          @include mqUp($bpKey) {
-            width: 100%;
-          }
-        }
-      }
-      $bpIndex: $bpIndex + 1;
     }
   }
+}
+
+.a-containerFluid {
+  display: flex;
+  margin: 0 auto;
+  width: 100%;
+}
+
+/**
+    .a-containerOnBp[breakpoint]
+
+    a-container spacing on specific breakpoint boundary
+ */
+$bpIndex: 1;
+$bpLength: length($breakpoints);
+
+@each $bpKey, $bpSize in $breakpoints {
+  .a-containerOnBp#{capitalize($bpKey)} {
+    @if ($bpIndex + 1) <= $bpLength {
+      $nextBpKey: nth(nth($breakpoints, ($bpIndex + 1)), 1);
+      @include mqBetween($bpKey, $nextBpKey) {
+        max-width: map-get($containerConfig, $bpKey);
+        width: 100%;
+      }
+    }
+    @else {
+      @include mq($bpKey) {
+        max-width: map-get($containerConfig, $bpKey);
+        width: 100%;
+      }
+    }
+
+  }
+
+  $bpIndex: $bpIndex + 1;
+}
+
+
+
+/**
+    .a-container-fluidOnBp[breakpoint]
+
+    a-container-fluid spacing on specific breakpoint boundary
+ */
+$bpIndex: 1;
+$bpLength: length($breakpoints);
+
+@each $bpKey, $bpSize in $breakpoints {
+  .a-containerFluidOnBp#{capitalize($bpKey)} {
+    @if ($bpIndex + 1) <= $bpLength {
+      $nextBpKey: nth(nth($breakpoints, ($bpIndex + 1)), 1);
+      @include mqBetween($bpKey, $nextBpKey) {
+        max-width: 100%;
+        width: 100%;
+      }
+    }
+    @else {
+      @include mq($bpKey) {
+        max-width: 100%;
+        width: 100%;
+      }
+    }
+
+  }
+
+  $bpIndex: $bpIndex + 1;
 }

--- a/src/scss/03_molecules/_accordionGroup.scss
+++ b/src/scss/03_molecules/_accordionGroup.scss
@@ -1,7 +1,4 @@
-.m-accordionGroup .a-accordion:not(:last-child) .a-accordion__toggle {
-  border-bottom: 1px solid color(shape);
+.m-accordionGroup .a-accordion:not(:first-child) .a-accordion__toggle {
+  border-top: none;
 }
 
-.m-accordionGroup .a-accordion:not(:last-child).a-accordion--dark .a-accordion__toggle {
-  border-bottom: 1px solid color(shape, dark);
-}

--- a/src/scss/04_organisms/_login.scss
+++ b/src/scss/04_organisms/_login.scss
@@ -1,6 +1,8 @@
 .o-login {
+
   background: color(background);
   flex-direction: column;
+  max-width: map-get($containerConfig, xsmall);
   padding: 20px;
 
   @include mq(small) {
@@ -21,7 +23,7 @@
   }
 
   .a-form__field {
-    
+
     @include mq(small) {
       justify-content: center
     }

--- a/src/test/accordions.html
+++ b/src/test/accordions.html
@@ -44,14 +44,14 @@
     <hr/>
     <div class="m-accordionGroup">
         <div id="accordionLight5" class="a-accordion a-accordion--base">
-	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
+	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a base accordion
 		        <i class="a-icon a-icon-info"></i>
 	        </span>
             <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
         </div>
         <div id="accordionLight6" class="a-accordion is-open a-accordion--base">
 
-            <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
+            <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a base accordion
                 <i class="a-icon a-icon-info"></i>
             </span>
             <div class="a-accordion__content fs-small">Lorem ipsum dolor sit amet,
@@ -69,8 +69,8 @@
             </div>
         </div>
 
-        <div id="accordionLight7" class="a-accordion a-accordion--dark">
-	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
+        <div id="accordionLight7" class="a-accordion a-accordion--base">
+	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a base accordion
 		        <i class="a-icon a-icon-info"></i>
 	        </span>
             <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>

--- a/src/test/accordions.html
+++ b/src/test/accordions.html
@@ -1,0 +1,133 @@
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body>
+<h1 class="alignCenter">Accordions</h1>
+<div class="a-container directionColumn">
+    <h1 class="">Regular container</h1>
+    <h2 class="">Accordion group</h2>
+    <div class="m-accordionGroup">
+        <div id="accordionLight1" class="a-accordion a-accordion--light">
+	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
+		        <i class="a-icon a-icon-info"></i>
+	        </span>
+            <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+        </div>
+        <div id="accordionLight2" class="a-accordion is-open a-accordion--light">
+
+            <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
+                <i class="a-icon a-icon-info"></i>
+            </span>
+                <div class="a-accordion__content fs-small">Lorem ipsum dolor sit amet,
+                    consectetur adipiscing elit, sed do
+                    eiusmod tempor incididunt ut labore et
+                    dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+                    aliquip
+                    ex ea
+                    commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+                    fugiat nulla
+                    pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+                    anim
+                    id
+                    est laborum.
+                </div>
+        </div>
+
+        <div id="accordionLight3" class="a-accordion a-accordion--light">
+	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
+		        <i class="a-icon a-icon-info"></i>
+	        </span>
+            <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+        </div>
+    </div>
+    <hr/>
+    <div class="m-accordionGroup">
+        <div id="accordionLight5" class="a-accordion a-accordion--base">
+	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
+		        <i class="a-icon a-icon-info"></i>
+	        </span>
+            <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+        </div>
+        <div id="accordionLight6" class="a-accordion is-open a-accordion--base">
+
+            <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
+                <i class="a-icon a-icon-info"></i>
+            </span>
+            <div class="a-accordion__content fs-small">Lorem ipsum dolor sit amet,
+                consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et
+                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+                aliquip
+                ex ea
+                commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+                fugiat nulla
+                pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+                anim
+                id
+                est laborum.
+            </div>
+        </div>
+
+        <div id="accordionLight7" class="a-accordion a-accordion--dark">
+	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
+		        <i class="a-icon a-icon-info"></i>
+	        </span>
+            <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+        </div>
+    </div>
+    <hr/>
+    <div class="m-accordionGroup">
+        <div id="accordionLight8" class="a-accordion a-accordion--dark">
+	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a dark accordion
+		        <i class="a-icon a-icon-info"></i>
+	        </span>
+            <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+        </div>
+        <div id="accordionLight9" class="a-accordion is-open a-accordion--dark">
+
+            <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a dark accordion
+                <i class="a-icon a-icon-info"></i>
+            </span>
+            <div class="a-accordion__content fs-small">Lorem ipsum dolor sit amet,
+                consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et
+                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+                aliquip
+                ex ea
+                commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+                fugiat nulla
+                pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+                anim
+                id
+                est laborum.
+            </div>
+        </div>
+
+        <div id="accordionLight10" class="a-accordion a-accordion--dark">
+	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a dark accordion
+		        <i class="a-icon a-icon-info"></i>
+	        </span>
+            <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+        </div>
+    </div>
+    <hr/>
+    <h3>I'm a single accordion</h3>
+    <div id="accordionLight4" class="a-accordion">
+	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a single classic accordion
+		        <i class="a-icon a-icon-info"></i>
+	        </span>
+        <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+    </div>
+    <hr/>
+</div>
+<script type="text/javascript">
+    document.querySelectorAll('.a-accordion__toggle').forEach((el) => {
+        el.addEventListener('click', (evt) => {
+            el.parentElement.classList.toggle('is-open')
+
+        })
+    })
+</script>
+</body>
+</html>

--- a/src/test/accordions.html
+++ b/src/test/accordions.html
@@ -1,6 +1,7 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="/pyxis.css" rel="stylesheet"/>
 </head>
 <body>
 <h1 class="alignCenter">Accordions</h1>

--- a/src/test/accordions.html
+++ b/src/test/accordions.html
@@ -54,7 +54,7 @@
             <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a base accordion
                 <i class="a-icon a-icon-info"></i>
             </span>
-            <div class="a-accordion__content fs-small">Lorem ipsum dolor sit amet,
+            <div class="a-accordion__content fs-small"><img alt="test" src="https://cdn.pixabay.com/photo/2013/07/12/17/47/test-pattern-152459_960_720.png"> <p>Lorem ipsum dolor sit amet,
                 consectetur adipiscing elit, sed do
                 eiusmod tempor incididunt ut labore et
                 dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -65,7 +65,7 @@
                 pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
                 anim
                 id
-                est laborum.
+                est laborum.</p>
             </div>
         </div>
 

--- a/src/test/accordions.html
+++ b/src/test/accordions.html
@@ -9,18 +9,18 @@
     <h1 class="">Regular container</h1>
     <h2 class="">Accordion group</h2>
     <div class="m-accordionGroup">
-        <div id="accordionLight1" class="a-accordion a-accordion--light">
+        <div class="a-accordion a-accordion--light">
 	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
 		        <i class="a-icon a-icon-info"></i>
 	        </span>
-            <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+            <div class="a-accordion__content fs-small"><p class="fsSmall">Lorem ipsum dolor .</div>
         </div>
-        <div id="accordionLight2" class="a-accordion is-open a-accordion--light">
+        <div class="a-accordion is-open a-accordion--light">
 
             <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
                 <i class="a-icon a-icon-info"></i>
             </span>
-                <div class="a-accordion__content fs-small">Lorem ipsum dolor sit amet,
+                <div class="a-accordion__content fs-small"><p class="fsSmall">Lorem ipsum dolor sit amet,
                     consectetur adipiscing elit, sed do
                     eiusmod tempor incididunt ut labore et
                     dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -31,31 +31,33 @@
                     pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
                     anim
                     id
-                    est laborum.
+                    est laborum.</p>
                 </div>
         </div>
 
-        <div id="accordionLight3" class="a-accordion a-accordion--light">
+        <div class="a-accordion a-accordion--light">
 	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
 		        <i class="a-icon a-icon-info"></i>
 	        </span>
-            <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+            <div class="a-accordion__content fs-small"><p class="fsSmall">Lorem ipsum dolor .</div>
         </div>
     </div>
     <hr/>
     <div class="m-accordionGroup">
-        <div id="accordionLight5" class="a-accordion a-accordion--base">
+        <div class="a-accordion a-accordion--base">
 	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a base accordion
 		        <i class="a-icon a-icon-info"></i>
 	        </span>
-            <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+            <div class="a-accordion__content fs-small"><p class="fsSmall">Lorem ipsum dolor .</div>
         </div>
-        <div id="accordionLight6" class="a-accordion is-open a-accordion--base">
+        <div class="a-accordion is-open a-accordion--base">
 
             <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a base accordion
                 <i class="a-icon a-icon-info"></i>
             </span>
-            <div class="a-accordion__content fs-small"><img alt="test" src="https://cdn.pixabay.com/photo/2013/07/12/17/47/test-pattern-152459_960_720.png"> <p>Lorem ipsum dolor sit amet,
+            <div class="a-accordion__content fs-small">
+                <img alt="test" src="https://cdn.pixabay.com/photo/2013/07/12/17/47/test-pattern-152459_960_720.png"> 
+                <p class="fsSmall">Lorem ipsum dolor sit amet,
                 consectetur adipiscing elit, sed do
                 eiusmod tempor incididunt ut labore et
                 dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -70,27 +72,27 @@
             </div>
         </div>
 
-        <div id="accordionLight7" class="a-accordion a-accordion--base">
+        <div class="a-accordion a-accordion--base">
 	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a base accordion
 		        <i class="a-icon a-icon-info"></i>
 	        </span>
-            <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+            <div class="a-accordion__content fs-small"><p class="fsSmall">Lorem ipsum dolor .</div>
         </div>
     </div>
     <hr/>
     <div class="m-accordionGroup">
-        <div id="accordionLight8" class="a-accordion a-accordion--dark">
+        <div class="a-accordion a-accordion--dark">
 	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a dark accordion
 		        <i class="a-icon a-icon-info"></i>
 	        </span>
-            <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+            <div class="a-accordion__content fs-small"><p class="fsSmall">Lorem ipsum dolor .</div>
         </div>
-        <div id="accordionLight9" class="a-accordion is-open a-accordion--dark">
+        <div class="a-accordion is-open a-accordion--dark">
 
             <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a dark accordion
                 <i class="a-icon a-icon-info"></i>
             </span>
-            <div class="a-accordion__content fs-small">Lorem ipsum dolor sit amet,
+            <div class="a-accordion__content fs-small"><p class="fsSmall">Lorem ipsum dolor sit amet,
                 consectetur adipiscing elit, sed do
                 eiusmod tempor incididunt ut labore et
                 dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -101,24 +103,24 @@
                 pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
                 anim
                 id
-                est laborum.
+                est laborum.</p>
             </div>
         </div>
 
-        <div id="accordionLight10" class="a-accordion a-accordion--dark">
+        <div" class="a-accordion a-accordion--dark">
 	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a dark accordion
 		        <i class="a-icon a-icon-info"></i>
 	        </span>
-            <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+            <div class="a-accordion__content fs-small"><p class="fsSmall">Lorem ipsum dolor .</div>
         </div>
     </div>
     <hr/>
     <h3>I'm a single accordion</h3>
-    <div id="accordionLight4" class="a-accordion">
+    <div class="a-accordion">
 	        <span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a single classic accordion
 		        <i class="a-icon a-icon-info"></i>
 	        </span>
-        <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+        <div class="a-accordion__content fs-small"><p class="fsSmall">Lorem ipsum dolor .</div>
     </div>
     <hr/>
 </div>

--- a/src/test/buttons.html
+++ b/src/test/buttons.html
@@ -1,6 +1,7 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="/pyxis.css" rel="stylesheet"/>
 </head>
 <body>
 <div class="a-container-fluid a-container-fluid--untilBpSmall directionColumn">

--- a/src/test/buttons.html
+++ b/src/test/buttons.html
@@ -1,7 +1,6 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/pyxis.css" rel="stylesheet"/>
 </head>
 <body>
 <div class="a-container-fluid a-container-fluid--untilBpSmall directionColumn">

--- a/src/test/buttons.html
+++ b/src/test/buttons.html
@@ -4,7 +4,7 @@
     <link href="/pyxis.css" rel="stylesheet"/>
 </head>
 <body>
-<div class="a-container directionColumn">
+<div class="a-container-fluid a-container-fluid--untilBpSmall directionColumn">
     <h3>Buttons (button group)</h3>
     <div class="m-btnGroup">
         <button class="a-btn a-btn--callout"><span>A</span></button>

--- a/src/test/containers.html
+++ b/src/test/containers.html
@@ -1,11 +1,23 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/pyxis.css" rel="stylesheet"/>
 </head>
 <body class="bgBackgroundDark">
 <h1 class="alignCenter">Containers</h1>
-<div class= "a-container directionColumn">
+<div class="a-container directionColumn">
+    <h1>Regular container</h1>
+    <h2>Title 2</h2>
+    <h3>Title 3</h3>
+    <h4>title 4</h4>
+    <p>Paragraph: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+        dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+        est laborum.</p>
+
+</div>
+<hr/>
+<div class="a-container directionColumn">
     <h1>Regular container</h1>
     <h2>Title 2</h2>
     <h3>Title 3</h3>
@@ -16,14 +28,8 @@
         pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
         est laborum.</p>
 </div>
-<div id="accordionLight" class="is-open a-accordion a-accordion--dark">
-	<span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
-		<i class="a-icon a-icon-info"></i>
-	</span>
-    <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
-</div>
 <hr/>
-<div class= "a-containerFluid directionColumn bgBackgroundBase">
+<div class="a-containerFluid directionColumn bgBackgroundBase">
     <h1>Fluid container</h1>
     <h2>Title 2</h2>
     <h3>Title 3</h3>
@@ -34,18 +40,6 @@
         pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
         est laborum.</p>
 
-    <div id="accordionLight" class="a-accordion a-accordion--light">
-	<span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
-		<i class="a-icon a-icon-info"></i>
-	</span>
-        <div class="a-accordion__content fs-small">Lorem ipsum dolor sit amet consectetur adipisicing elit. Consequuntur in rerum amet modi nobis maxime autem? Et, iure tempora libero dolorem soluta ipsum, quas vero veritatis ea debitis aut ut.</div>
-    </div>
-    <div id="accordionLight" class="a-accordion a-accordion--light">
-	<span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
-		<i class="a-icon a-icon-info"></i>
-	</span>
-        <div class="a-accordion__content fs-small">Lorem ipsum dolor sit amet consectetur adipisicing elit. Consequuntur in rerum amet modi nobis maxime autem? Et, iure tempora libero dolorem soluta ipsum, quas vero veritatis ea debitis aut ut.</div>
-    </div>
 </div>
 <hr/>
 <div class="bgBackgroundBase a-containerFluid a-containerOnBpMedium a-containerOnBpLarge a-containerOnBpXlarge directionColumn">
@@ -83,5 +77,6 @@
         pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
         est laborum.</p>
 </div>
+<hr/>
 </body>
 </html>

--- a/src/test/containers.html
+++ b/src/test/containers.html
@@ -1,6 +1,7 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="/pyxis.css" rel="stylesheet"/>
 </head>
 <body class="bgBackgroundDark">
 <h1 class="alignCenter">Containers</h1>

--- a/src/test/containers.html
+++ b/src/test/containers.html
@@ -1,0 +1,87 @@
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="/pyxis.css" rel="stylesheet"/>
+</head>
+<body class="bgBackgroundDark">
+<h1 class="alignCenter">Containers</h1>
+<div class= "a-container directionColumn">
+    <h1>Regular container</h1>
+    <h2>Title 2</h2>
+    <h3>Title 3</h3>
+    <h4>title 4</h4>
+    <p>Paragraph: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+        dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+        est laborum.</p>
+</div>
+<div id="accordionLight" class="is-open a-accordion a-accordion--dark">
+	<span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
+		<i class="a-icon a-icon-info"></i>
+	</span>
+    <div class="a-accordion__content fs-small">Lorem ipsum dolor .</div>
+</div>
+<hr/>
+<div class= "a-containerFluid directionColumn bgBackgroundBase">
+    <h1>Fluid container</h1>
+    <h2>Title 2</h2>
+    <h3>Title 3</h3>
+    <h4>title 4</h4>
+    <p>Paragraph: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+        dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+        est laborum.</p>
+
+    <div id="accordionLight" class="a-accordion a-accordion--light">
+	<span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
+		<i class="a-icon a-icon-info"></i>
+	</span>
+        <div class="a-accordion__content fs-small">Lorem ipsum dolor sit amet consectetur adipisicing elit. Consequuntur in rerum amet modi nobis maxime autem? Et, iure tempora libero dolorem soluta ipsum, quas vero veritatis ea debitis aut ut.</div>
+    </div>
+    <div id="accordionLight" class="a-accordion a-accordion--light">
+	<span class="a-accordion__toggle fs-xsmall fw-heavy a-link--alt">I am a light accordion
+		<i class="a-icon a-icon-info"></i>
+	</span>
+        <div class="a-accordion__content fs-small">Lorem ipsum dolor sit amet consectetur adipisicing elit. Consequuntur in rerum amet modi nobis maxime autem? Et, iure tempora libero dolorem soluta ipsum, quas vero veritatis ea debitis aut ut.</div>
+    </div>
+</div>
+<hr/>
+<div class="bgBackgroundBase a-containerFluid a-containerOnBpMedium a-containerOnBpLarge a-containerOnBpXlarge directionColumn">
+    <h1>Fluid container, regular from medium</h1>
+    <h2>Title 2</h2>
+    <h3>Title 3</h3>
+    <h4>title 4</h4>
+    <p>Paragraph: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+        dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+        est laborum.</p>
+</div>
+<hr/>
+<div class="bgBackgroundBase a-containerFluid a-containerOnBpMedium directionColumn">
+    <h1>Fluid but regular on Medium</h1>
+    <h2>Title 2</h2>
+    <h3>Title 3</h3>
+    <h4>title 4</h4>
+    <p>Paragraph: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+        dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+        est laborum.</p>
+</div>
+<hr/>
+<div class="bgBackgroundBase a-container a-containerFluidOnBpMedium directionColumn">
+    <h1>Regular but fluid on medium</h1>
+    <h2>Title 2</h2>
+    <h3>Title 3</h3>
+    <h4>title 4</h4>
+    <p>Paragraph: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+        dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+        est laborum.</p>
+</div>
+</body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,12 +74,16 @@ module.exports = (env, argv) => {
             new HtmlWebpackPlugin({
                 filename: 'test/containers.html',
                 template: 'test/containers.html'
+            }),
+            new HtmlWebpackPlugin({
+                filename: 'test/accordions.html',
+                template: 'test/accordions.html'
             })
         ],
         devServer: {
             compress: false,
             port: 8080,
-            disableHostCheck: false
+            disableHostCheck: true
         }
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,17 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 
 module.exports = (env, argv) => {
     const devMode = argv.mode !== 'production'
-    console.log('devMode?', devMode)
+    const testPlugin = 
+        ['accordions', 
+         'buttons',
+         'containers',
+        ].map(template => {
+            return new HtmlWebpackPlugin({ 
+                filename: `test/${template}.html`, 
+                template: `test/${template}.html` 
+            })
+        })
+
     let conf = {
 
         context: path.resolve(__dirname, 'src'),
@@ -62,24 +72,12 @@ module.exports = (env, argv) => {
                 }
             ],
         },
-        plugins: [
+        plugins: ([
             new CleanWebpackPlugin(),
             new MiniCssExtractPlugin({
                 filename: '[name].css'
             }),
-            new HtmlWebpackPlugin({
-                filename: 'test/buttons.html',
-                template: 'test/buttons.html'
-            }),
-            new HtmlWebpackPlugin({
-                filename: 'test/containers.html',
-                template: 'test/containers.html'
-            }),
-            new HtmlWebpackPlugin({
-                filename: 'test/accordions.html',
-                template: 'test/accordions.html'
-            })
-        ],
+        ]).concat(testPlugin),
         devServer: {
             compress: false,
             port: 8080,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,8 +68,12 @@ module.exports = (env, argv) => {
                 filename: '[name].css'
             }),
             new HtmlWebpackPlugin({
-                filename: 'test.html',
-                template: 'test/index.html'
+                filename: 'test/buttons.html',
+                template: 'test/buttons.html'
+            }),
+            new HtmlWebpackPlugin({
+                filename: 'test/containers.html',
+                template: 'test/containers.html'
             })
         ],
         devServer: {


### PR DESCRIPTION
### 1.8.15
**sass changes**

Login
- added max width equal to `a-container` xsmall

Container
- **BREAKING-CHANGE**: Removed previously introduced `a-container--fluidOnBp
- **BREAKING-CHANGE**: `a-container--fluid` removed in favour of `a-containerFluid` 
- Now you can have containers of certain type that changes behaviour on certain breakpoints combining `a-container` and `a-containerFluid` with `a-containerOn[breakpoint]` and `a-containerFluidOn[breakpoint]` 

Accordion
- Accordion now have double border on top and bottom (accordion group modified to support this)

Utils
- Add `rem` function to get `rem` value by passing a `px` value. At the moment this function will always return the `px` result. We planned a full switch to `rem` units in later release

