### PR TITLE
Accordion content fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 
 ### 1.8.16
-**sass changes**
+**sass fix**
 
 Accordion
 - Accordion content now sets childrens to `display: none;` until they become visibile by opening the accordion itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### 1.8.16
+**sass changes**
+
+Accordion
+- Accordion content now sets childrens to `display: none;` until they become visibile by opening the accordion itself.
+
 ### 1.8.15
 **sass changes**
 

--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ After install launch webpack dev server in watch mode on your machine
 ````bash
 yarn serve
 ````
-You can edit the test file in `src/test/index.html`. The page is reachable @ http://localhost:8080/test.html .
+You can edit the test file in `src/test/myTestFile.html`. The page is reachable @ http://localhost:8080/test/myTestFile.html .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prima-assicurazioni/pyxis-npm",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "description": "Pyxis SASS provided by a simple NPM package",
   "main": "src/scss/pyxis.scss",
   "scripts": {

--- a/src/scss/02_atoms/_accordion.scss
+++ b/src/scss/02_atoms/_accordion.scss
@@ -70,7 +70,7 @@
   &:before, 
   &:after {
     background: color(brandAlt);
-    content: ' ';
+    content: '';
     position: absolute;
     height: map-get($accordionConfig, iconHeight);
     width: map-get($accordionConfig, iconWidth);
@@ -87,7 +87,7 @@
   padding: 0 map-get($accordionConfig, accordionPadding);
   opacity: 0;
   overflow: hidden;
-  transition: opacity 0.3s, padding 0.3s, flex 0.3s, visibility 0.3s;
+  transition: opacity 0.3s, padding 0.3s, flex 0.3s;
   visibility: hidden;
 
   .a-accordion.is-open & {
@@ -102,4 +102,8 @@
   .a-accordion.is-open.a-accordion--dark & {
     border-bottom: 1px solid color(shape, dark);
   }
+}
+
+.a-accordion:not(.is-open) .a-accordion__content > * {
+  display: none;
 }

--- a/src/test/accordions.html
+++ b/src/test/accordions.html
@@ -1,7 +1,6 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/pyxis.css" rel="stylesheet"/>
 </head>
 <body>
 <h1 class="alignCenter">Accordions</h1>


### PR DESCRIPTION
### 1.8.16
**sass fix**

Accordion
- Accordion content now sets childrens to `display: none;` until they become visibile by opening the accordion itself.